### PR TITLE
feat: add vercel deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ If you want to run the latest code from git, here's how to get started:
 
         npm start
 
+## Deploying to Vercel
+
+This repository includes a minimal configuration for running Node-RED on [Vercel](https://vercel.com).
+The `api/index.js` file wraps Node-RED in an Express application and `vercel.json`
+sets up the build and routing.
+
+1. Install the Vercel CLI: `npm i -g vercel`
+2. Run `vercel` in the project root and follow the prompts.
+3. Open `https://<your-app>.vercel.app/red` to access the editor.
+
 ## Contributing
 
 Before raising a pull-request, please read our

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const http = require('http');
+const RED = require('node-red');
+
+const app = express();
+const server = http.createServer(app);
+
+const settings = {
+    httpAdminRoot: '/red',
+    httpNodeRoot: '/',
+    userDir: './',
+    functionGlobalContext: {}
+};
+
+let started = false;
+async function init() {
+    if (!started) {
+        RED.init(server, settings);
+        app.use(settings.httpAdminRoot, RED.httpAdmin);
+        app.use(settings.httpNodeRoot, RED.httpNode);
+        await RED.start();
+        started = true;
+    }
+}
+
+module.exports = async function(req, res) {
+    await init();
+    app(req, res);
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "api/index.js", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "api/index.js" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Vercel configuration for running Node-RED
- wrap Node-RED in Express app for serverless deployment
- document deployment steps

## Testing
- `npm test` *(fails: Task "simplemocha:all" failed, aborted due to warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6892eb1ec0f88329838c66fa8a503b7d